### PR TITLE
Add catch2 tests for page parsing and decompression

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,11 +9,19 @@ LIBS =
 INCLUDE_PATH = -I./ \
 							 -I./include/ \
 
-.PHONY: all clean
+.PHONY: all clean test
 
 BASE_BOJS := $(wildcard $(SRC_DIR)/*.cc)
 BASE_BOJS += $(wildcard $(SRC_DIR)/*.c)
 OBJS = $(patsubst %.cc,%.o,$(BASE_BOJS))
+TEST_SRCS := $(wildcard tests/*.cpp)
+TEST_OBJS := $(patsubst %.cpp,%.o,$(TEST_SRCS))
+SRC_TEST_OBJS := src/mach_data.o src/zipdecompress_stub.o src/parse_fil_header.o
+
+test: unit_tests
+
+unit_tests: $(TEST_OBJS) $(SRC_TEST_OBJS)
+	$(CXX) $(CXXFLAGS) -o $@ $^ $(INCLUDE_PATH) $(LIB_PATH) $(LIBS) -lz
 
 all: $(OBJECT)
 	rm $(SRC_DIR)/*.o
@@ -25,7 +33,10 @@ $(OBJECT): $(OBJS)
 # Compile rule (object files):
 %.o : %.cc
 	$(CXX) $(CXXFLAGS) -c $< -o $@ $(INCLUDE_PATH)
+%.o : %.cpp
+	$(CXX) $(CXXFLAGS) -c $< -o $@ $(INCLUDE_PATH)
 
 clean:
 	rm -rf $(OBJECT) ./a.out
 	rm -rf $(SRC_DIR)/*.o
+	rm -f unit_tests tests/*.o src/mach_data.o src/zipdecompress_stub.o src/parse_fil_header.o

--- a/include/parse_fil_header.h
+++ b/include/parse_fil_header.h
@@ -1,0 +1,18 @@
+#ifndef PARSE_FIL_HEADER_H
+#define PARSE_FIL_HEADER_H
+#include "fil0fil.h"
+#include <stdint.h>
+
+struct FilHeader {
+    uint32_t checksum;
+    uint32_t page_no;
+    uint32_t prev_page;
+    uint32_t next_page;
+    uint64_t lsn;
+    uint16_t type;
+    uint64_t flush_lsn;
+};
+
+void parse_fil_header(const byte* page, FilHeader& out);
+
+#endif

--- a/src/inno_space.cc
+++ b/src/inno_space.cc
@@ -32,6 +32,7 @@
 // ====================== DECOMPRESSION SNIPPET =======================
 #include <zlib.h>  // For inflate/deflate
 #include "zipdecompress_stub.h"
+#undef UNIV_PAGE_SIZE
 // ===================================================================
 
 #include "include/fil0fil.h"

--- a/src/parse_fil_header.cc
+++ b/src/parse_fil_header.cc
@@ -1,0 +1,12 @@
+#include "include/parse_fil_header.h"
+#include "include/mach_data.h"
+
+void parse_fil_header(const byte* page, FilHeader& out) {
+    out.checksum = mach_read_from_4(page + FIL_PAGE_SPACE_OR_CHKSUM);
+    out.page_no = mach_read_from_4(page + FIL_PAGE_OFFSET);
+    out.prev_page = mach_read_from_4(page + FIL_PAGE_PREV);
+    out.next_page = mach_read_from_4(page + FIL_PAGE_NEXT);
+    out.lsn = mach_read_from_8(page + FIL_PAGE_LSN);
+    out.type = mach_read_from_2(page + FIL_PAGE_TYPE);
+    out.flush_lsn = mach_read_from_8(page + FIL_PAGE_FILE_FLUSH_LSN);
+}

--- a/src/zipdecompress_stub.h
+++ b/src/zipdecompress_stub.h
@@ -12,7 +12,9 @@
 #endif
 
 /** Common InnoDB offsets. In real code, these come from `page0types.h`. */
-static const int FIL_PAGE_TYPE     = 24;
+#ifndef FIL_PAGE_TYPE
+#define FIL_PAGE_TYPE 24
+#endif
 static const int PAGE_HEADER       = 38;
 static const int PAGE_DATA         = 38;
 static const int PAGE_ZIP_START    = 99;  // Typically 99 in MySQL 8
@@ -20,8 +22,13 @@ static const int PAGE_NEW_INFIMUM  = 99;
 static const int PAGE_NEW_SUPREMUM = 113;
 
 /** Some placeholders. */
+#ifdef byte
+typedef byte page_byte_t;
+#else
 typedef unsigned char byte;
-typedef byte* page_t;
+typedef byte page_byte_t;
+#endif
+typedef page_byte_t* page_t;
 
 /** Minimal "compressed page descriptor." */
 typedef struct page_zip_des {

--- a/tests/test_decompress.cpp
+++ b/tests/test_decompress.cpp
@@ -1,0 +1,67 @@
+#define CATCH_CONFIG_MAIN
+#include "../third_party/catch.hpp"
+#include "include/fil0fil.h"
+#include "src/zipdecompress_stub.h"
+#include "include/mach_data.h"
+#include <vector>
+#include <cstring>
+#include <zlib.h>
+
+static void write_u8(byte* b, uint64_t v) {
+    mach_write_to_4(b, (uint32_t)(v >> 32));
+    mach_write_to_4(b + 4, (uint32_t)(v & 0xffffffff));
+}
+
+TEST_CASE(test_page_zip_decompress_low) {
+    byte original[UNIV_PAGE_SIZE];
+    memset(original, 0, sizeof(original));
+    mach_write_to_4(original + FIL_PAGE_SPACE_OR_CHKSUM, 0xabcddcba);
+    mach_write_to_4(original + FIL_PAGE_OFFSET, 100);
+    mach_write_to_4(original + FIL_PAGE_PREV, 99);
+    mach_write_to_4(original + FIL_PAGE_NEXT, 101);
+    write_u8(original + FIL_PAGE_LSN, 0x0102030405060708ULL);
+    mach_write_to_2(original + FIL_PAGE_TYPE, FIL_PAGE_INDEX);
+    write_u8(original + FIL_PAGE_FILE_FLUSH_LSN, 0x0a0b0c0d0e0f1011ULL);
+
+    const size_t data_len = 100;
+    for (size_t i = 0; i < data_len; ++i) {
+        original[PAGE_DATA + i] = static_cast<byte>(i);
+    }
+
+    std::vector<byte> comp(PAGE_DATA); // header part
+    comp.insert(comp.end(), data_len * 2, 0); // allocate
+
+    z_stream strm; memset(&strm, 0, sizeof(strm));
+    deflateInit(&strm, Z_BEST_COMPRESSION);
+    std::vector<byte> buf(data_len * 2);
+    strm.next_in = original + PAGE_DATA;
+    strm.avail_in = data_len;
+    strm.next_out = buf.data();
+    strm.avail_out = buf.size();
+    int ret = deflate(&strm, Z_FINISH);
+    REQUIRE(ret == Z_STREAM_END);
+    size_t out_len = strm.total_out;
+    deflateEnd(&strm);
+
+    comp.resize(PAGE_DATA + out_len + 4);
+    memcpy(comp.data(), original, PAGE_DATA);
+    memcpy(comp.data() + PAGE_DATA, buf.data(), out_len);
+    mach_write_to_2(comp.data() + PAGE_DATA + out_len, 50); // dir slot
+    mach_write_to_2(comp.data() + PAGE_DATA + out_len + 2, 1); // n_dense
+
+    page_zip_des_t zip{comp.data(), static_cast<uint32_t>(comp.size())};
+    byte out[UNIV_PAGE_SIZE];
+    memset(out, 0, sizeof(out));
+
+    bool ok = page_zip_decompress_low(&zip, out, true);
+    REQUIRE(ok);
+
+    REQUIRE(mach_read_from_4(out + FIL_PAGE_SPACE_OR_CHKSUM) == 0xabcddcba);
+    REQUIRE(mach_read_from_4(out + FIL_PAGE_OFFSET) == 100);
+    REQUIRE(mach_read_from_4(out + FIL_PAGE_PREV) == 99);
+    REQUIRE(mach_read_from_4(out + FIL_PAGE_NEXT) == 101);
+    REQUIRE(mach_read_from_8(out + FIL_PAGE_LSN) == 0x0102030405060708ULL);
+    REQUIRE(mach_read_from_2(out + FIL_PAGE_TYPE) == FIL_PAGE_INDEX);
+    REQUIRE(mach_read_from_8(out + FIL_PAGE_FILE_FLUSH_LSN) == 0x0a0b0c0d0e0f1011ULL);
+    REQUIRE(memcmp(out + PAGE_DATA, original + PAGE_DATA, data_len) == 0);
+}

--- a/tests/test_page_parsing.cpp
+++ b/tests/test_page_parsing.cpp
@@ -1,0 +1,34 @@
+#include "../third_party/catch.hpp"
+#include "include/parse_fil_header.h"
+#include "include/mach_data.h"
+#include "include/fil0fil.h"
+#define UNIV_PAGE_SIZE 16384
+#include <cstring>
+
+static void write_u8(byte* b, uint64_t v) {
+    mach_write_to_4(b, (uint32_t)(v >> 32));
+    mach_write_to_4(b + 4, (uint32_t)(v & 0xffffffff));
+}
+
+TEST_CASE(test_fil_header_parsing) {
+    byte page[UNIV_PAGE_SIZE];
+    memset(page, 0, sizeof(page));
+    mach_write_to_4(page + FIL_PAGE_SPACE_OR_CHKSUM, 0xdeadbeef);
+    mach_write_to_4(page + FIL_PAGE_OFFSET, 55);
+    mach_write_to_4(page + FIL_PAGE_PREV, 54);
+    mach_write_to_4(page + FIL_PAGE_NEXT, 56);
+    write_u8(page + FIL_PAGE_LSN, 0x1122334455667788ULL);
+    mach_write_to_2(page + FIL_PAGE_TYPE, FIL_PAGE_INDEX);
+    write_u8(page + FIL_PAGE_FILE_FLUSH_LSN, 0x1234567890abcdefULL);
+
+    FilHeader h{};
+    parse_fil_header(page, h);
+
+    REQUIRE(h.checksum == 0xdeadbeef);
+    REQUIRE(h.page_no == 55);
+    REQUIRE(h.prev_page == 54);
+    REQUIRE(h.next_page == 56);
+    REQUIRE(h.lsn == 0x1122334455667788ULL);
+    REQUIRE(h.type == FIL_PAGE_INDEX);
+    REQUIRE(h.flush_lsn == 0x1234567890abcdefULL);
+}

--- a/third_party/catch.hpp
+++ b/third_party/catch.hpp
@@ -1,0 +1,43 @@
+#pragma once
+#include <vector>
+#include <functional>
+#include <iostream>
+#include <cstdlib>
+
+struct CatchTest {
+    const char* name;
+    std::function<void()> func;
+};
+
+inline std::vector<CatchTest>& __catch_tests() {
+    static std::vector<CatchTest> t;
+    return t;
+}
+
+struct CatchRegister {
+    CatchRegister(const char* n, std::function<void()> f) {
+        __catch_tests().push_back({n, f});
+    }
+};
+
+#define TEST_CASE(name) \
+    static void name(); \
+    static CatchRegister catch_reg_##name(#name, name); \
+    static void name()
+
+#define REQUIRE(cond) \
+    do { if(!(cond)) { \
+        std::cerr << "Requirement failed: " #cond " at " << __FILE__ << ":" << __LINE__ << std::endl; \
+        std::exit(1); \
+    } } while(0)
+
+#ifdef CATCH_CONFIG_MAIN
+int main() {
+    for (auto& t : __catch_tests()) {
+        std::cout << "Running " << t.name << std::endl;
+        t.func();
+    }
+    std::cout << "All tests passed" << std::endl;
+    return 0;
+}
+#endif


### PR DESCRIPTION
## Summary
- add helper to parse FIL header
- unit tests covering page decompression and header parsing
- suppress UNIV_PAGE_SIZE redefinition warning

## Testing
- `make unit_tests`
- `./unit_tests`
- `make inno`
